### PR TITLE
Add options to connector functions, and only allow resolveWithFullRes…

### DIFF
--- a/lib/connector.js
+++ b/lib/connector.js
@@ -41,18 +41,18 @@ MYOBConnector.prototype._rp = function (options) {
   return requestPromise(options);
 };
 
-MYOBConnector.prototype.get = function (path) {
-  return this._request('GET', path);
+MYOBConnector.prototype.get = function (path, options) {
+  return this._request('GET', path, null, null, options);
 };
 
-MYOBConnector.prototype.post = function (path, data) {
-  return this._request('POST', path, null, data);
+MYOBConnector.prototype.post = function (path, data, options) {
+  return this._request('POST', path, null, data, options);
 };
-MYOBConnector.prototype.put = function (path, data) {
-  return this._request('PUT', path, null, data);
+MYOBConnector.prototype.put = function (path, data, options) {
+  return this._request('PUT', path, null, data, options);
 };
-MYOBConnector.prototype.delete = function (path) {
-  return this._request('DELETE', path);
+MYOBConnector.prototype.delete = function (path, options) {
+  return this._request('DELETE', path, null, null, options);
 };
 
 MYOBConnector.prototype._generateUrl = function (path, queryParams) {
@@ -99,7 +99,7 @@ MYOBConnector.prototype._refreshAccessToken = function () {
       ]);
     });
 };
-MYOBConnector.prototype._request = function (method, path, queryParams, data) {
+MYOBConnector.prototype._request = function (method, path, queryParams, data, optionsToAdd) {
   return BBPromise.try(function makeRequest() {
     if (!path) {
       throw new errors.connector.request.InvalidError('no path specified');
@@ -123,6 +123,11 @@ MYOBConnector.prototype._request = function (method, path, queryParams, data) {
         "x-myobapi-cftoken": new Buffer(this.authorization.get('username') + ":" + this.authorization.get('password')).toString('base64')
       }
     };
+
+    if (optionsToAdd) {
+      options = _.extend(options, _.pick(optionsToAdd, ["resolveWithFullResponse"])); //Only allow certain options to be overridden
+    }
+    
     if (data) {
       options.body = data;
     }


### PR DESCRIPTION
Allow users to set options when calling the connector methods, but not allow them to set any old thing.  

Only resolveWithFullResponse for now.
